### PR TITLE
fix: Remove deprecated force_text import from django.utils.encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,5 @@ will publish the package to PyPi. You will need to enter the username and passwo
 
 - Remove deprecated force_text import from django.utils.encoding.
 - - Affects giant-plugins version: 0.6.x
+- - Branch: [Release 0.6.x](https://github.com/giantmade/giant-plugins/tree/release/0.6.x)
 - - Dependency restrictions: django = ">=4.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Giant Plugins
 
-A re-usable package which can be used in any project that requires a base set of plugins. 
+A re-usable package which can be used in any project that requires a base set of plugins.
 
 This will include a small set of plugins that are used in a large number of projects, but will not necessarily cover the full requirements. It will also provide a RichText field which can be used in other areas of the project
 The RichText field uses ![summernote](https://github.com/summernote/summernote/) for styling the WYSIWYG widget.
@@ -11,7 +11,7 @@ To install with the package manager, run:
 
     $ poetry add giant-plugins
 
-You should then add `"giant_plugins"` to the `INSTALLED_APPS` in `base.py`.  
+You should then add `"giant_plugins"` to the `INSTALLED_APPS` in `base.py`.
 
 In order to run `django-admin` commands you will need to set the `DJANGO_SETTINGS_MODULE` by running
 
@@ -58,19 +58,29 @@ In order to specify a form to use for a specific plugin you should add something
 Where PLUGIN_NAME is the capitalised name of the plugin (e.g `TEXTWITHIMAGEPLUGIN_FORM`) and the path to the form class as a string so it can be imported.
 
  ## Preparing for release
- 
+
  In order to prep the package for a new release on TestPyPi and PyPi there is one key thing that you need to do. You need to update the version number in the `pyproject.toml`.
  This is so that the package can be published without running into version number conflicts. The version numbering must also follow the Semantic Version rules which can be found here https://semver.org/.
- 
- 
+
+
  ## Publishing
- 
+
  Publishing a package with poetry is incredibly easy. Once you have checked that the version number has been updated (not the same as a previous version) then you only need to run two commands.
- 
-    $ `poetry build` 
+
+    $ `poetry build`
 
 will package the project up for you into a way that can be published.
- 
+
     $ `poetry publish`
 
 will publish the package to PyPi. You will need to enter the username and password for the account which can be found in the company password manager
+
+# Changelog
+
+[2025-2-7]
+
+## Fixed
+
+- Remove deprecated force_text import from django.utils.encoding.
+- - Affects giant-plugins version: 0.6.x
+- - Dependency restrictions: django = ">=4.1"

--- a/giant_plugins/utils.py
+++ b/giant_plugins/utils.py
@@ -9,7 +9,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.forms import Media, Textarea
 from django.forms.utils import flatatt
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.safestring import mark_safe
 
@@ -22,7 +22,7 @@ def get_setting(setting: str) -> Optional[object]:
 class LazyEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super().default(obj)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,19 +22,19 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.12"
 django-filer = "*"
 giant-mixins = "*"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
+pytest = "*"
 black = "^19.10b0"
-django-cms = "^3.7.2"
-django = "2.2"
-pytest-cov = "^2.10.0"
-pytest-django = "^3.9.0"
-six = "^1.15.0"
-django-polymorphic = "3.0.0"
+django-cms = "^3.11"
+django = "^5.0"
+pytest-cov = "*"
+pytest-django = "*"
+six = "*"
+django-polymorphic = "*"
 
 [[tool.poetry.source]]
 name = "TestPyPi"


### PR DESCRIPTION
To reflect a Django 4.x requirement